### PR TITLE
Update the implementation of pagination

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -1,4 +1,3 @@
-
 package catalog
 
 import (
@@ -33,7 +32,7 @@ type CatalogController interface {
 	update(id string, d ThingDescription) error
 	patch(id string, d ThingDescription) error
 	delete(id string) error
-	list(page, perPage int) ([]ThingDescription, int, error)
+	list(offset, limit int) ([]ThingDescription, int, error)
 	listAllBytes() ([]byte, error)
 	// Deprecated
 	filterJSONPath(path string, page, perPage int) ([]interface{}, int, error)
@@ -57,7 +56,7 @@ type Storage interface {
 	update(id string, td ThingDescription) error
 	delete(id string) error
 	get(id string) (ThingDescription, error)
-	list(page, perPage int) ([]ThingDescription, int, error)
+	list(offset, limit int) ([]ThingDescription, int, error)
 	listAllBytes() ([]byte, error)
 	total() (int, error)
 	iterator() <-chan ThingDescription

--- a/catalog/controller.go
+++ b/catalog/controller.go
@@ -1,4 +1,3 @@
-
 package catalog
 
 import (
@@ -15,8 +14,8 @@ import (
 	jsonpath "github.com/bhmj/jsonslice"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/linksmart/service-catalog/v3/utils"
-	"github.com/tinyiot/thing-directory/wot"
 	uuid "github.com/satori/go.uuid"
+	"github.com/tinyiot/thing-directory/wot"
 )
 
 var controllerExpiryCleanupInterval = 60 * time.Second // to be modified in unit tests
@@ -198,8 +197,15 @@ func (c *Controller) delete(id string) error {
 	return nil
 }
 
-func (c *Controller) list(page, perPage int) ([]ThingDescription, int, error) {
-	tds, total, err := c.storage.list(page, perPage)
+func (c *Controller) list(offset, limit int) ([]ThingDescription, int, error) {
+	if offset < 0 || limit < 0 {
+		return nil, 0, fmt.Errorf("offset and limit must not be negative")
+	}
+	if limit > MaxLimit {
+		return nil, 0, fmt.Errorf("limit must be smaller than %s", MaxLimit)
+	}
+
+	tds, total, err := c.storage.list(offset, limit)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/main.go
+++ b/main.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -17,11 +16,11 @@ import (
 	_ "github.com/linksmart/go-sec/auth/keycloak/obtainer"
 	_ "github.com/linksmart/go-sec/auth/keycloak/validator"
 	"github.com/linksmart/go-sec/auth/validator"
+	"github.com/rs/cors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/tinyiot/thing-directory/catalog"
 	"github.com/tinyiot/thing-directory/notification"
 	"github.com/tinyiot/thing-directory/wot"
-	"github.com/rs/cors"
-	uuid "github.com/satori/go.uuid"
 )
 
 const TinyIoT = `
@@ -222,13 +221,13 @@ func setupHTTPRouter(config *HTTPConfig, api *catalog.HTTPAPI, notifAPI *notific
 
 	// Deprecated: use /things and /search instead
 	// TD CRUD, listing, filtering
-	r.get("/td", commonHandlers.ThenFunc(api.GetMany))
-	r.get("/td-chunked", commonHandlers.ThenFunc(api.GetAll))
-	r.post("/td", commonHandlers.ThenFunc(api.Post))
-	r.get("/td/{id:.+}", commonHandlers.ThenFunc(api.Get))
-	r.put("/td/{id:.+}", commonHandlers.ThenFunc(api.Put))
-	r.patch("/td/{id:.+}", commonHandlers.ThenFunc(api.Patch))
-	r.delete("/td/{id:.+}", commonHandlers.ThenFunc(api.Delete))
+	// r.get("/td", commonHandlers.ThenFunc(api.GetMany))
+	// r.get("/td-chunked", commonHandlers.ThenFunc(api.GetAll))
+	// r.post("/td", commonHandlers.ThenFunc(api.Post))
+	// r.get("/td/{id:.+}", commonHandlers.ThenFunc(api.Get))
+	// r.put("/td/{id:.+}", commonHandlers.ThenFunc(api.Put))
+	// r.patch("/td/{id:.+}", commonHandlers.ThenFunc(api.Patch))
+	// r.delete("/td/{id:.+}", commonHandlers.ThenFunc(api.Delete))
 
 	// CRUDL
 	r.post("/things", commonHandlers.ThenFunc(api.Post))             // create anonymous
@@ -236,7 +235,7 @@ func setupHTTPRouter(config *HTTPConfig, api *catalog.HTTPAPI, notifAPI *notific
 	r.get("/things/{id:.+}", commonHandlers.ThenFunc(api.Get))       // retrieve
 	r.patch("/things/{id:.+}", commonHandlers.ThenFunc(api.Patch))   // partially update
 	r.delete("/things/{id:.+}", commonHandlers.ThenFunc(api.Delete)) // delete
-	r.get("/things", commonHandlers.ThenFunc(api.GetAll))            // listing
+	r.get("/things", commonHandlers.ThenFunc(api.List))              // listing
 
 	// search
 	r.get("/search/jsonpath", commonHandlers.ThenFunc(api.SearchJSONPath))


### PR DESCRIPTION
Based on the latest spec, pagination should use `limit` and `offset` rather than `page` and `per_page`.

Spec: https://w3c.github.io/wot-discovery/#exploration-directory-api-things-listing